### PR TITLE
改进包含图片时弹幕滚动速度不受控制的问题

### DIFF
--- a/lib/danmu/danmu/commentframe.js
+++ b/lib/danmu/danmu/commentframe.js
@@ -78,7 +78,7 @@ module.exports = {
 				y: y,
 				width: width,
 				height: height,
-				speed: generateSpeed(style, x, y, lifeTime),
+				speed: generateSpeed(style, x, y, lifeTime, text),
 				text: text,
 				lifeTime: lifeTime,
 				color: color,
@@ -90,10 +90,15 @@ module.exports = {
 			 * @param style 弹幕类型
 			 * @returns speed{}
 			 */
-			function generateSpeed(style, x, y, lifeTime) {
+			function generateSpeed(style, x, y, lifeTime, text) {
+				var newstrvar = text.replace(/\[IMG WIDTH=\d+\][^\[]*?\[\/IMG\]/gmi,"QQQQ");
+				var oldLength = text.length;
+				var newLength = newstrvar.length;
 				if (style == "scroll") {
 					return {
-						x: -(x + width) / lifeTime, //-(移动距离+文本宽度)/(移动时间*帧数)
+						//x: -(x + width) / lifeTime, //-(移动距离+文本宽度)/(移动时间*帧数)
+						//-((移动距离+文本宽度+1到10的随机数)/(移动时间*帧数))
+						x: -(x +  Math.ceil((width * newLength) / oldLength) + Math.ceil(Math.random()*10)) / lifeTime,
 						y: 0
 					};
 				} else if (style == "reversescroll") {


### PR DESCRIPTION
改进包含图片时弹幕滚动速度不受控制的问题（https://github.com/zsxsoft/danmu-client/issues/8），

即重新计算图片宽度（每个图片占4个Q字符）并加入1到10的随机宽度来生成比较合适的动态速度值。

Signed-off-by: TomWu phperwuhan@gmail.com
